### PR TITLE
Vitis import example

### DIFF
--- a/debug_port.h
+++ b/debug_port.h
@@ -16,3 +16,11 @@ void name##_DEBUG(type_t val_input) \
 { \
   name = val_input;\
 }
+
+#define DECL_OUTPUT(type_t, name) \
+type_t name; \
+PRAGMA_MESSAGE(MAIN name) \
+type_t name() \
+{ \
+  return name; \
+}

--- a/examples/vitis_import/README.txt
+++ b/examples/vitis_import/README.txt
@@ -1,0 +1,7 @@
+Source Xilinx env first!
+
+If you wish to use HW-emu for now you must comment float_pkg from VHDL sources...
+Change TARGET to "HW_EMU"
+and run test:
+export XCL_EMULATION_MODE=hw_emu
+./main kernel.xclbin

--- a/examples/vitis_import/axis.c
+++ b/examples/vitis_import/axis.c
@@ -1,46 +1,27 @@
 #include "uintN_t.h"
 #include "axi/axis.h"
+#include "debug_port.h"
 
-#pragma MAIN axis_test
-// Not using axis32_t in output struct 
-// since conversion to verilog makes nested structs ugly
-typedef struct axis_test_t{
-  uint32_t axis_out_data;
-  uint4_t axis_out_keep;
-  uint1_t axis_out_valid;
-  uint1_t axis_in_ready;
-}axis_test_t;
-axis_test_t axis_test(
-  axis32_t axis_in,
-  uint1_t axis_out_ready
-)
-{
-  // Simple demo doing +1 on each element
-  axis_test_t o;
-  o.axis_out_data = axis_in.data + 1;
-  o.axis_out_keep = axis_in.keep;
-  o.axis_out_valid = axis_in.valid;
-  o.axis_in_ready = axis_out_ready;
-  return o;
-}
+DECL_OUTPUT(uint32_t, out_data)
+DECL_OUTPUT(uint1_t, out_valid)
+DECL_OUTPUT(uint1_t, in_ready)
 
-/*
-// static buffer, not autopipelined
-// State is buffer of axis data
-static axis32_t axis_data;
-// Output signals
-axis_test_t o;
-// Ready if buffer is empty
-o.axis_in_ready = !axis_data.valid;
-// Output is from buffer
-o.axis_out_data = axis_data;
-// Buffer written when ready for inputs
-// Cleared when ready for output
-if(o.axis_in_ready){
-  axis_data = axis_in_data;
-} else if(axis_out_ready){
-  axis_data.valid = 0;
+#pragma MAIN pipelineC_ip
+#pragma MAIN_MHZ pipelineC_ip 300.0
+#pragma PART "xcu50-fsvh2104-2-e"
+
+void pipelineC_ip (
+    uint32_t in_data,
+    uint1_t in_valid,
+    uint1_t out_ready
+) {
+    if (in_valid & out_ready) {
+        out_data = in_data + 1;
+        out_valid = 1;
+        in_ready = 1;
+    } else {
+        out_data = 0;
+        out_valid = 0;
+        in_ready = 0;
+    }
 }
-// Data is transfered if valid and ready
-uint1_t input_xfer_now = axis_in_data.valid & o.axis_in_ready;
-*/

--- a/examples/vitis_import/build.sh
+++ b/examples/vitis_import/build.sh
@@ -1,0 +1,2 @@
+ #!/bin/bash
+../../src/pipelinec axis.c --out_dir OUT

--- a/examples/vitis_import/vitis_scripts/.gitignore
+++ b/examples/vitis_import/vitis_scripts/.gitignore
@@ -1,0 +1,14 @@
+*.log
+*.jou
+*.link_summary
+project_1
+.Xil
+.ipcache
+_x
+o
+xo
+main
+ip_repo
+kernel.ltx
+kernel.xclbin
+kernel.xclbin.info

--- a/examples/vitis_import/vitis_scripts/build_all.sh
+++ b/examples/vitis_import/vitis_scripts/build_all.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+TARGET=hw
+#TARGET=hw_emu
+VITIS_PLATFORM=xilinx_u50_gen3x16_xdma_5_202210_1
+vivado -source sources/package_xo.tcl -mode batch
+./vitis_compile.sh ${TARGET} ${VITIS_PLATFORM}
+./vitis_link.sh ${TARGET} ${VITIS_PLATFORM}
+./gpp.sh
+./test.sh

--- a/examples/vitis_import/vitis_scripts/clean.sh
+++ b/examples/vitis_import/vitis_scripts/clean.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+rm -rf *.log
+rm -rf *.jou
+rm -rf *.link_summary
+rm -rf project_1
+rm -rf .Xil
+rm -rf .ipcache
+rm -rf _x
+rm -rf o
+rm -rf xo
+rm -rf main
+rm -rf ip_repo
+rm -rf kernel.ltx
+rm -rf kernel.xclbin
+rm -rf kernel.xclbin.info

--- a/examples/vitis_import/vitis_scripts/gpp.sh
+++ b/examples/vitis_import/vitis_scripts/gpp.sh
@@ -1,0 +1,20 @@
+ #!/bin/bash
+mkdir -p o
+
+g++ -c \
+    -I${XILINX_XRT}/include \
+    -D__USE_XOPEN2K8 \
+    -o o/main.o sources/main.cpp
+g++ -c \
+    -I${XILINX_XRT}/include \
+    -D__USE_XOPEN2K8 \
+    -o o/xcl2.o includes/xcl2.cpp
+
+g++ -Wall \
+    -o main o/*.o \
+    -lxilinxopencl \
+    -lxrt_coreutil \
+    -lpthread \
+    -lrt \
+    -lstdc++ \
+    -L${XILINX_XRT}/lib

--- a/examples/vitis_import/vitis_scripts/includes/xcl2.cpp
+++ b/examples/vitis_import/vitis_scripts/includes/xcl2.cpp
@@ -1,0 +1,180 @@
+/**
+* Copyright (C) 2019-2021 Xilinx, Inc
+*
+* Licensed under the Apache License, Version 2.0 (the "License"). You may
+* not use this file except in compliance with the License. A copy of the
+* License is located at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
+
+#include "xcl2.hpp"
+#include <climits>
+#include <sys/stat.h>
+#include <string>
+#include <iomanip>
+#include <sstream>
+#if defined(_WINDOWS)
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace xcl {
+std::vector<cl::Device> get_devices(const std::string& vendor_name) {
+    size_t i;
+    cl_int err;
+    std::vector<cl::Platform> platforms;
+    OCL_CHECK(err, err = cl::Platform::get(&platforms));
+    cl::Platform platform;
+    for (i = 0; i < platforms.size(); i++) {
+        platform = platforms[i];
+        OCL_CHECK(err, std::string platformName = platform.getInfo<CL_PLATFORM_NAME>(&err));
+        if (!(platformName.compare(vendor_name))) {
+            std::cout << "Found Platform" << std::endl;
+            std::cout << "Platform Name: " << platformName.c_str() << std::endl;
+            break;
+        }
+    }
+    if (i == platforms.size()) {
+        std::cout << "Error: Failed to find Xilinx platform" << std::endl;
+        std::cout << "Found the following platforms : " << std::endl;
+        for (size_t j = 0; j < platforms.size(); j++) {
+            platform = platforms[j];
+            OCL_CHECK(err, std::string platformName = platform.getInfo<CL_PLATFORM_NAME>(&err));
+            std::cout << "Platform Name: " << platformName.c_str() << std::endl;
+        }
+        exit(EXIT_FAILURE);
+    }
+    // Getting ACCELERATOR Devices and selecting 1st such device
+    std::vector<cl::Device> devices;
+    OCL_CHECK(err, err = platform.getDevices(CL_DEVICE_TYPE_ACCELERATOR, &devices));
+    return devices;
+}
+
+std::vector<cl::Device> get_xil_devices() {
+    return get_devices("Xilinx");
+}
+
+cl::Device find_device_bdf(const std::vector<cl::Device>& devices, const std::string& bdf) {
+    char device_bdf[20];
+    cl_int err;
+    cl::Device device;
+    int cnt = 0;
+    for (uint32_t i = 0; i < devices.size(); i++) {
+        OCL_CHECK(err, err = devices[i].getInfo(CL_DEVICE_PCIE_BDF, &device_bdf));
+        if (bdf == device_bdf) {
+            device = devices[i];
+            cnt++;
+            break;
+        }
+    }
+    if (cnt == 0) {
+        std::cout << "Invalid device bdf. Please check and provide valid bdf\n";
+        exit(EXIT_FAILURE);
+    }
+    return device;
+}
+cl_device_id find_device_bdf_c(cl_device_id* devices, const std::string& bdf, cl_uint device_count) {
+    char device_bdf[20];
+    cl_int err;
+    cl_device_id device;
+    int cnt = 0;
+    for (uint32_t i = 0; i < device_count; i++) {
+        err = clGetDeviceInfo(devices[i], CL_DEVICE_PCIE_BDF, sizeof(device_bdf), device_bdf, 0);
+        if (err != CL_SUCCESS) {
+            std::cout << "Unable to extract the device BDF details\n";
+            exit(EXIT_FAILURE);
+        }
+        if (bdf == device_bdf) {
+            device = devices[i];
+            cnt++;
+            break;
+        }
+    }
+    if (cnt == 0) {
+        std::cout << "Invalid device bdf. Please check and provide valid bdf\n";
+        exit(EXIT_FAILURE);
+    }
+    return device;
+}
+std::vector<unsigned char> read_binary_file(const std::string& xclbin_file_name) {
+    std::cout << "INFO: Reading " << xclbin_file_name << std::endl;
+    FILE* fp;
+    if ((fp = fopen(xclbin_file_name.c_str(), "r")) == nullptr) {
+        printf("ERROR: %s xclbin not available please build\n", xclbin_file_name.c_str());
+        exit(EXIT_FAILURE);
+    }
+    // Loading XCL Bin into char buffer
+    std::cout << "Loading: '" << xclbin_file_name.c_str() << "'\n";
+    std::ifstream bin_file(xclbin_file_name.c_str(), std::ifstream::binary);
+    bin_file.seekg(0, bin_file.end);
+    auto nb = bin_file.tellg();
+    bin_file.seekg(0, bin_file.beg);
+    std::vector<unsigned char> buf;
+    buf.resize(nb);
+    bin_file.read(reinterpret_cast<char*>(buf.data()), nb);
+    return buf;
+}
+
+bool is_emulation() {
+    bool ret = false;
+    char* xcl_mode = getenv("XCL_EMULATION_MODE");
+    if (xcl_mode != nullptr) {
+        ret = true;
+    }
+    return ret;
+}
+
+bool is_hw_emulation() {
+    bool ret = false;
+    char* xcl_mode = getenv("XCL_EMULATION_MODE");
+    if ((xcl_mode != nullptr) && !strcmp(xcl_mode, "hw_emu")) {
+        ret = true;
+    }
+    return ret;
+}
+double round_off(double n) {
+    double d = n * 100.0;
+    int i = d + 0.5;
+    d = i / 100.0;
+    return d;
+}
+
+std::string convert_size(size_t size) {
+    static const char* SIZES[] = {"B", "KB", "MB", "GB"};
+    uint32_t div = 0;
+    size_t rem = 0;
+
+    while (size >= 1024 && div < (sizeof SIZES / sizeof *SIZES)) {
+        rem = (size % 1024);
+        div++;
+        size /= 1024;
+    }
+
+    double size_d = (float)size + (float)rem / 1024.0;
+    double size_val = round_off(size_d);
+
+    std::stringstream stream;
+    stream << std::fixed << std::setprecision(2) << size_val;
+    std::string size_str = stream.str();
+    std::string result = size_str + " " + SIZES[div];
+    return result;
+}
+
+bool is_xpr_device(const char* device_name) {
+    const char* output = strstr(device_name, "xpr");
+
+    if (output == nullptr) {
+        return false;
+    } else {
+        return true;
+    }
+}
+}; // namespace xcl

--- a/examples/vitis_import/vitis_scripts/includes/xcl2.hpp
+++ b/examples/vitis_import/vitis_scripts/includes/xcl2.hpp
@@ -1,0 +1,119 @@
+/*
+* Copyright (C) 2019-2021 Xilinx, Inc
+*
+* Licensed under the Apache License, Version 2.0 (the "License"). You may
+* not use this file except in compliance with the License. A copy of the
+* License is located at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
+
+#pragma once
+
+#define CL_HPP_CL_1_2_DEFAULT_BUILD
+#define CL_HPP_TARGET_OPENCL_VERSION 120
+#define CL_HPP_MINIMUM_OPENCL_VERSION 120
+#define CL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY 1
+#define CL_USE_DEPRECATED_OPENCL_1_2_APIS
+
+// OCL_CHECK doesn't work if call has templatized function call
+#define OCL_CHECK(error, call)                                                                   \
+    call;                                                                                        \
+    if (error != CL_SUCCESS) {                                                                   \
+        printf("%s:%d Error calling " #call ", error code is: %d\n", __FILE__, __LINE__, error); \
+        exit(EXIT_FAILURE);                                                                      \
+    }
+
+#include <CL/cl2.hpp>
+#include <CL/cl_ext_xilinx.h>
+#include <fstream>
+#include <iostream>
+// When creating a buffer with user pointer (CL_MEM_USE_HOST_PTR), under the
+// hood
+// User ptr is used if and only if it is properly aligned (page aligned). When
+// not
+// aligned, runtime has no choice but to create its own host side buffer that
+// backs
+// user ptr. This in turn implies that all operations that move data to and from
+// device incur an extra memcpy to move data to/from runtime's own host buffer
+// from/to user pointer. So it is recommended to use this allocator if user wish
+// to
+// Create Buffer/Memory Object with CL_MEM_USE_HOST_PTR to align user buffer to
+// the
+// page boundary. It will ensure that user buffer will be used when user create
+// Buffer/Mem Object with CL_MEM_USE_HOST_PTR.
+template <typename T>
+struct aligned_allocator {
+    using value_type = T;
+
+    aligned_allocator() {}
+
+    aligned_allocator(const aligned_allocator&) {}
+
+    template <typename U>
+    aligned_allocator(const aligned_allocator<U>&) {}
+
+    T* allocate(std::size_t num) {
+        void* ptr = nullptr;
+
+#if defined(_WINDOWS)
+        {
+            ptr = _aligned_malloc(num * sizeof(T), 4096);
+            if (ptr == nullptr) {
+                std::cout << "Failed to allocate memory" << std::endl;
+                exit(EXIT_FAILURE);
+            }
+        }
+#else
+        {
+            if (posix_memalign(&ptr, 4096, num * sizeof(T))) throw std::bad_alloc();
+        }
+#endif
+        return reinterpret_cast<T*>(ptr);
+    }
+    void deallocate(T* p, std::size_t num) {
+#if defined(_WINDOWS)
+        _aligned_free(p);
+#else
+        free(p);
+#endif
+    }
+};
+
+namespace xcl {
+std::vector<cl::Device> get_xil_devices();
+std::vector<cl::Device> get_devices(const std::string& vendor_name);
+cl::Device find_device_bdf(const std::vector<cl::Device>& devices, const std::string& bdf);
+cl_device_id find_device_bdf_c(cl_device_id* devices, const std::string& bdf, cl_uint dev_count);
+std::string convert_size(size_t size);
+std::vector<unsigned char> read_binary_file(const std::string& xclbin_file_name);
+bool is_emulation();
+bool is_hw_emulation();
+bool is_xpr_device(const char* device_name);
+class P2P {
+   public:
+    static decltype(&xclGetMemObjectFd) getMemObjectFd;
+    static decltype(&xclGetMemObjectFromFd) getMemObjectFromFd;
+    static void init(const cl_platform_id& platform) {
+        void* bar = clGetExtensionFunctionAddressForPlatform(platform, "xclGetMemObjectFd");
+        getMemObjectFd = (decltype(&xclGetMemObjectFd))bar;
+        bar = clGetExtensionFunctionAddressForPlatform(platform, "xclGetMemObjectFromFd");
+        getMemObjectFromFd = (decltype(&xclGetMemObjectFromFd))bar;
+    }
+};
+class Ext {
+   public:
+    static decltype(&xclGetComputeUnitInfo) getComputeUnitInfo;
+    static void init(const cl_platform_id& platform) {
+        void* bar = clGetExtensionFunctionAddressForPlatform(platform, "xclGetComputeUnitInfo");
+        getComputeUnitInfo = (decltype(&xclGetComputeUnitInfo))bar;
+    }
+};
+}
+

--- a/examples/vitis_import/vitis_scripts/sources/main.cpp
+++ b/examples/vitis_import/vitis_scripts/sources/main.cpp
@@ -1,0 +1,107 @@
+/**
+* Copyright (C) 2019-2021 Xilinx, Inc
+*
+* Licensed under the Apache License, Version 2.0 (the "License"). You may
+* not use this file except in compliance with the License. A copy of the
+* License is located at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
+
+// Original source file can be found in Xilinx Github repository
+// https://github.com/Xilinx/Vitis_Accel_Examples/blob/master/hello_world/src/host.cpp
+// This file is modified!
+
+#include "../includes/xcl2.hpp"
+#include <algorithm>
+#include <vector>
+#define DATA_SIZE 64
+
+int main(int argc, char** argv) {
+    if (argc != 2) {
+        std::cout << "Usage: " << argv[0] << " <XCLBIN File>" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    std::string binaryFile = argv[1];
+    size_t vector_size_bytes = sizeof(int) * DATA_SIZE;
+    cl_int err;
+    cl::Context context;
+    cl::Kernel krnl_maxi_to_stream;
+    cl::Kernel krnl_stream_to_maxi;
+    cl::CommandQueue q;
+
+    std::vector<int, aligned_allocator<int> > source_in1(DATA_SIZE);
+    std::vector<int, aligned_allocator<int> > source_hw_results(DATA_SIZE);
+    std::vector<int, aligned_allocator<int> > source_sw_results(DATA_SIZE);
+
+    // Create the test data
+    std::generate(source_in1.begin(), source_in1.end(), std::rand);
+    for (int i = 0; i < DATA_SIZE; i++) {
+        source_sw_results[i] = source_in1[i] + 1;
+        source_hw_results[i] = 0;
+    }
+
+    auto devices = xcl::get_xil_devices();
+    auto fileBuf = xcl::read_binary_file(binaryFile);
+    cl::Program::Binaries bins{{fileBuf.data(), fileBuf.size()}};
+    bool valid_device = false;
+    for (unsigned int i = 0; i < devices.size(); i++) {
+        auto device = devices[i];
+        // Creating Context and Command Queue for selected Device
+        OCL_CHECK(err, context = cl::Context(device, nullptr, nullptr, nullptr, &err));
+        OCL_CHECK(err, q = cl::CommandQueue(context, device, CL_QUEUE_PROFILING_ENABLE | CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE, &err));
+        std::cout << "Trying to program device[" << i << "]: " << device.getInfo<CL_DEVICE_NAME>() << std::endl;
+        cl::Program program(context, {device}, bins, nullptr, &err);
+        if (err != CL_SUCCESS) {
+            std::cout << "Failed to program device[" << i << "] with xclbin file!\n";
+        } else {
+            std::cout << "Device[" << i << "]: program successful!\n";
+            OCL_CHECK(err, krnl_maxi_to_stream = cl::Kernel(program, "maxi_to_stream", &err));
+            OCL_CHECK(err, krnl_stream_to_maxi = cl::Kernel(program, "stream_to_maxi", &err));
+            valid_device = true;
+            break; // we break because we found a valid device
+        }
+    }
+    if (!valid_device) {
+        std::cout << "Failed to program any device found, exit!\n";
+        exit(EXIT_FAILURE);
+    }
+
+    OCL_CHECK(err, cl::Buffer buffer_in(context, CL_MEM_USE_HOST_PTR | CL_MEM_READ_ONLY, vector_size_bytes,
+                                         source_in1.data(), &err));
+    OCL_CHECK(err, cl::Buffer buffer_output(context, CL_MEM_USE_HOST_PTR | CL_MEM_WRITE_ONLY, vector_size_bytes,
+                                            source_hw_results.data(), &err));
+
+    unsigned int size = DATA_SIZE;
+    OCL_CHECK(err, err = krnl_maxi_to_stream.setArg(0, buffer_in));
+    OCL_CHECK(err, err = krnl_maxi_to_stream.setArg(2, size));
+    OCL_CHECK(err, err = krnl_stream_to_maxi.setArg(1, buffer_output));
+    OCL_CHECK(err, err = krnl_stream_to_maxi.setArg(2, size));
+    OCL_CHECK(err, err = q.enqueueMigrateMemObjects({buffer_in}, 0 /* 0 means from host*/));
+    OCL_CHECK(err, err = q.enqueueTask(krnl_maxi_to_stream));
+    OCL_CHECK(err, err = q.enqueueTask(krnl_stream_to_maxi));
+    q.finish();
+    OCL_CHECK(err, err = q.enqueueMigrateMemObjects({buffer_output}, CL_MIGRATE_MEM_OBJECT_HOST));
+    q.finish();
+
+    bool match = true;
+    for (int i = 0; i < DATA_SIZE; i++) {
+        if (source_hw_results[i] != source_sw_results[i]) {
+            std::cout << "Error: Result mismatch" << std::endl;
+            std::cout << "i = " << i << " CPU result = " << source_sw_results[i]
+                      << " Device result = " << source_hw_results[i] << std::endl;
+            match = false;
+            break;
+        }
+    }
+
+    std::cout << "TEST " << (match ? "PASSED" : "FAILED") << std::endl;
+    return (match ? EXIT_SUCCESS : EXIT_FAILURE);
+}

--- a/examples/vitis_import/vitis_scripts/sources/maxi_to_stream.cpp
+++ b/examples/vitis_import/vitis_scripts/sources/maxi_to_stream.cpp
@@ -1,0 +1,12 @@
+#include <hls_stream.h>
+
+extern "C"
+void maxi_to_stream(
+    unsigned int *input,
+    hls::stream<unsigned int> &output,
+    unsigned int number_of_elements
+) {
+    for (unsigned int i = 0; i < number_of_elements; ++i) {
+        output.write(input[i]);
+    }
+}

--- a/examples/vitis_import/vitis_scripts/sources/package_xo.tcl
+++ b/examples/vitis_import/vitis_scripts/sources/package_xo.tcl
@@ -1,0 +1,48 @@
+set script_path [ file dirname [ file normalize [ info script ] ] ]
+set script_path $script_path/..
+puts $script_path
+set PIPELINEC_PROJ_DIR $script_path/../OUT
+
+source sources/utils.tcl
+
+create_project project_1 $script_path/project_1 -part xcu50-fsvh2104-2-e -force
+set_property board_part xilinx.com:au50:part0:1.3 [current_project]
+
+source ${PIPELINEC_PROJ_DIR}/read_vhdl.tcl
+set_property file_type {VHDL} [get_files  ${PIPELINEC_PROJ_DIR}/top/top.vhd]
+
+update_compile_order -fileset sources_1
+
+create_bd_design "my_ip"
+create_bd_cell -type module -reference top top_0
+make_bd_pins_external  [get_bd_cells top_0]
+make_bd_intf_pins_external  [get_bd_cells top_0]
+save_bd_design
+validate_bd_design
+
+make_wrapper -files [get_files $script_path/project_1/project_1.srcs/sources_1/bd/my_ip/my_ip.bd] -top
+add_files -norecurse $script_path/project_1/project_1.gen/sources_1/bd/my_ip/hdl/my_ip_wrapper.v
+set_property top my_ip_wrapper [current_fileset]
+update_compile_order -fileset sources_1
+
+ipx::package_project -root_dir $script_path/ip_repo -vendor user.org -library user -taxonomy /UserIP -module my_ip -import_files
+update_compile_order -fileset sources_1
+set_property ipi_drc {ignore_freq_hz false} [ipx::find_open_core user.org:user:my_ip:1.0]
+set_property sdx_kernel true [ipx::find_open_core user.org:user:my_ip:1.0]
+set_property sdx_kernel_type rtl [ipx::find_open_core user.org:user:my_ip:1.0]
+set_property vitis_drc {ctrl_protocol ap_ctrl_none} [ipx::find_open_core user.org:user:my_ip:1.0]
+set_property ipi_drc {ignore_freq_hz true} [ipx::find_open_core user.org:user:my_ip:1.0]
+
+map_clock clk_300p0_0
+map_axi_stream pipelineC_ip_in_data_0 pipelineC_ip_in_valid_0 in_ready_return_output_0 clk_300p0_0 input_stream slave
+map_axi_stream out_data_return_output_0 out_valid_return_output_0 pipelineC_ip_out_ready_0 clk_300p0_0 output_stream master
+
+set_property core_revision 1 [ipx::find_open_core user.org:user:my_ip:1.0]
+ipx::create_xgui_files [ipx::find_open_core user.org:user:my_ip:1.0]
+ipx::update_checksums [ipx::find_open_core user.org:user:my_ip:1.0]
+ipx::check_integrity -kernel -xrt [ipx::find_open_core user.org:user:my_ip:1.0]
+ipx::save_core [ipx::find_open_core user.org:user:my_ip:1.0]
+package_xo  -xo_path $script_path/xo/my_ip.xo -kernel_name my_ip -ip_directory $script_path/ip_repo -ctrl_protocol ap_ctrl_none -force
+update_ip_catalog
+ipx::check_integrity -quiet -kernel -xrt [ipx::find_open_core user.org:user:my_ip:1.0]
+ipx::archive_core $script_path/ip_repo/user.org_user_my_ip_1.0.zip [ipx::find_open_core user.org:user:my_ip:1.0]

--- a/examples/vitis_import/vitis_scripts/sources/stream_to_maxi.cpp
+++ b/examples/vitis_import/vitis_scripts/sources/stream_to_maxi.cpp
@@ -1,0 +1,12 @@
+#include <hls_stream.h>
+
+extern "C"
+void stream_to_maxi(
+    hls::stream<unsigned int> &input,
+    unsigned int *output,
+    unsigned int number_of_elements
+) {
+    for (unsigned int i = 0; i < number_of_elements; ++i) {
+        output[i] = input.read();
+    }
+}

--- a/examples/vitis_import/vitis_scripts/sources/utils.tcl
+++ b/examples/vitis_import/vitis_scripts/sources/utils.tcl
@@ -1,0 +1,18 @@
+proc map_clock {axi_clk} {
+    ipx::infer_bus_interface $axi_clk xilinx.com:signal:clock_rtl:1.0 [ipx::find_open_core user.org:user:my_ip:1.0]
+    ipx::add_bus_parameter FREQ_TOLERANCE_HZ [ipx::get_bus_interfaces $axi_clk -of_objects [ipx::current_core]]
+    set_property value -1 [ipx::get_bus_parameters FREQ_TOLERANCE_HZ -of_objects [ipx::get_bus_interfaces $axi_clk -of_objects [ipx::current_core]]]
+}
+proc map_axi_stream {data valid ready axi_clock port_name axi_type} {
+ipx::add_bus_interface $port_name [ipx::find_open_core user.org:user:my_ip:1.0]
+set_property abstraction_type_vlnv xilinx.com:interface:axis_rtl:1.0 [ipx::get_bus_interfaces $port_name -of_objects [ipx::find_open_core user.org:user:my_ip:1.0]]
+set_property interface_mode $axi_type [ipx::get_bus_interfaces $port_name -of_objects [ipx::find_open_core user.org:user:my_ip:1.0]]
+set_property bus_type_vlnv xilinx.com:interface:axis:1.0 [ipx::get_bus_interfaces $port_name -of_objects [ipx::find_open_core user.org:user:my_ip:1.0]]
+ipx::add_port_map TDATA [ipx::get_bus_interfaces $port_name -of_objects [ipx::find_open_core user.org:user:my_ip:1.0]]
+set_property physical_name $data [ipx::get_port_maps TDATA -of_objects [ipx::get_bus_interfaces $port_name -of_objects [ipx::find_open_core user.org:user:my_ip:1.0]]]
+ipx::add_port_map TVALID [ipx::get_bus_interfaces $port_name -of_objects [ipx::find_open_core user.org:user:my_ip:1.0]]
+set_property physical_name $valid [ipx::get_port_maps TVALID -of_objects [ipx::get_bus_interfaces $port_name -of_objects [ipx::find_open_core user.org:user:my_ip:1.0]]]
+ipx::add_port_map TREADY [ipx::get_bus_interfaces $port_name -of_objects [ipx::find_open_core user.org:user:my_ip:1.0]]
+set_property physical_name $ready [ipx::get_port_maps TREADY -of_objects [ipx::get_bus_interfaces $port_name -of_objects [ipx::find_open_core user.org:user:my_ip:1.0]]]
+ipx::associate_bus_interfaces -busif $port_name -clock $axi_clock [ipx::find_open_core user.org:user:my_ip:1.0]
+}

--- a/examples/vitis_import/vitis_scripts/sources/vitis_hls.cfg
+++ b/examples/vitis_import/vitis_scripts/sources/vitis_hls.cfg
@@ -1,0 +1,2 @@
+[profile]
+stall=all:all

--- a/examples/vitis_import/vitis_scripts/sources/vitis_link.cfg
+++ b/examples/vitis_import/vitis_scripts/sources/vitis_link.cfg
@@ -1,0 +1,7 @@
+[vivado]
+synth.jobs=4
+impl.jobs=12
+
+[connectivity]
+stream_connect=maxi_to_stream_1.output:my_ip_1.input_stream
+stream_connect=my_ip_1.output_stream:stream_to_maxi_1.input

--- a/examples/vitis_import/vitis_scripts/sources/xrt.ini
+++ b/examples/vitis_import/vitis_scripts/sources/xrt.ini
@@ -1,0 +1,15 @@
+[Debug]
+opencl_summary=true
+opencl_trace=true
+xrt_trace=false
+lop_trace=false
+power_profile=true
+data_transfer_trace=coarse
+device_trace=coarse
+host_trace=true
+stall_trace=all
+continuous_trace=true
+app_debug=true
+[Runtime]
+runtime_log=console
+verbosity=3

--- a/examples/vitis_import/vitis_scripts/test.sh
+++ b/examples/vitis_import/vitis_scripts/test.sh
@@ -1,0 +1,5 @@
+ #!/bin/bash
+#VITIS_PLATFORM=xilinx_u50_gen3x16_xdma_5_202210_1
+#export XCL_EMULATION_MODE=hw_emu
+#emconfigutil --nd 1  --platform ${VITIS_PLATFORM} --od .
+./main kernel.xclbin

--- a/examples/vitis_import/vitis_scripts/vitis_compile.sh
+++ b/examples/vitis_import/vitis_scripts/vitis_compile.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+v++ --compile \
+    --platform $2 \
+    --input_files sources/maxi_to_stream.cpp \
+    --config sources/vitis_hls.cfg \
+    --kernel maxi_to_stream \
+    --output xo/maxi_to_stream.xo \
+    --target $1
+v++ --compile \
+    --platform $2 \
+    --input_files sources/stream_to_maxi.cpp \
+    --config sources/vitis_hls.cfg \
+    --kernel stream_to_maxi \
+    --output xo/stream_to_maxi.xo \
+    --target $1

--- a/examples/vitis_import/vitis_scripts/vitis_link.sh
+++ b/examples/vitis_import/vitis_scripts/vitis_link.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+v++ --link \
+    --platform $2 \
+    --output kernel.xclbin \
+    --input_files xo/my_ip.xo \
+    --input_files xo/maxi_to_stream.xo \
+    --input_files xo/stream_to_maxi.xo \
+    --config sources/vitis_link.cfg \
+    --target $1 \
+    --save-temps


### PR DESCRIPTION
These scripts are used to generate Vitis hls IP's that transfer data to/from pipelineC generated IP. Streaming interfaces are used as communication channel. PipelineC ip is packaged as .XO and connected with Vitis at linking stage.